### PR TITLE
Updated dependencies and added prerequisites to run on macos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,10 @@ build = "build.rs"
 [dependencies]
 log = "0.4"
 env_logger = "0.7"
-ash = "0.31"
-ash-window = "0.5"
+ash = { version = "0.37.3", default-features = false, features = ["linked", "debug"] }
+ash-window = "0.12"
 cgmath = "0.17"
 image = "0.23"
 tobj = "2.0"
-winit = "0.22"
+winit = "0.28.0"
+raw-window-handle = "0.5.0"

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,13 +1,12 @@
 use ash::{
-    extensions::{ext::DebugReport, khr::Surface},
-    version::{DeviceV1_0, InstanceV1_0},
-    vk, Device, Entry, Instance,
+    extensions::{ext::DebugUtils, khr::Surface},
+    vk::{self, DebugUtilsMessengerEXT}, Device, Entry, Instance,
 };
 
 pub struct VkContext {
     _entry: Entry,
     instance: Instance,
-    debug_report_callback: Option<(DebugReport, vk::DebugReportCallbackEXT)>,
+    debugging_info: Option<(DebugUtils, vk::DebugUtilsMessengerEXT)>,
     surface: Surface,
     surface_khr: vk::SurfaceKHR,
     physical_device: vk::PhysicalDevice,
@@ -94,7 +93,7 @@ impl VkContext {
     pub fn new(
         entry: Entry,
         instance: Instance,
-        debug_report_callback: Option<(DebugReport, vk::DebugReportCallbackEXT)>,
+        debugging_info: Option<(DebugUtils, DebugUtilsMessengerEXT)>,
         surface: Surface,
         surface_khr: vk::SurfaceKHR,
         physical_device: vk::PhysicalDevice,
@@ -103,7 +102,7 @@ impl VkContext {
         VkContext {
             _entry: entry,
             instance,
-            debug_report_callback,
+            debugging_info,
             surface,
             surface_khr,
             physical_device,
@@ -117,8 +116,8 @@ impl Drop for VkContext {
         unsafe {
             self.device.destroy_device(None);
             self.surface.destroy_surface(self.surface_khr, None);
-            if let Some((report, callback)) = self.debug_report_callback.take() {
-                report.destroy_debug_report_callback(callback, None);
+            if let Some((debug_utils_loader, callback)) = self.debugging_info.take() {
+                debug_utils_loader.destroy_debug_utils_messenger(callback, None);
             }
             self.instance.destroy_instance(None);
         }

--- a/src/offset.rs
+++ b/src/offset.rs
@@ -1,0 +1,10 @@
+#[macro_export]
+macro_rules! offset_of {
+    ($base:path, $field:ident) => {{
+        #[allow(unused_unsafe)]
+        unsafe {
+            let b: $base = std::mem::zeroed();
+            std::ptr::addr_of!(b.$field) as isize - std::ptr::addr_of!(b) as isize
+        }
+    }};
+}

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -1,4 +1,4 @@
-use ash::{version::DeviceV1_0, vk, Device};
+use ash::{vk, Device};
 
 #[derive(Clone, Copy)]
 pub struct Texture {

--- a/src/vertex.rs
+++ b/src/vertex.rs
@@ -1,0 +1,47 @@
+use std::mem::size_of;
+use ash::vk;
+
+use crate::offset_of;
+
+#[derive(Clone, Copy, Debug)]
+#[allow(dead_code)]
+pub struct Vertex {
+    pub pos: [f32; 3],
+    pub color: [f32; 3],
+    pub coords: [f32; 2],
+}
+
+impl Vertex {
+    pub fn get_binding_description() -> vk::VertexInputBindingDescription {
+        vk::VertexInputBindingDescription::builder()
+            .binding(0)
+            .stride(size_of::<Vertex>() as _)
+            .input_rate(vk::VertexInputRate::VERTEX)
+            .build()
+    }
+
+    pub fn get_attribute_descriptions() -> [vk::VertexInputAttributeDescription; 3] {
+        let position_desc = vk::VertexInputAttributeDescription {
+            location: 0,
+            binding: 0,
+            format: vk::Format::R32G32B32_SFLOAT,
+            offset: offset_of!(Vertex, pos) as _,
+        };
+
+        let color_desc = vk::VertexInputAttributeDescription {
+            location: 1,
+            binding: 0,
+            format: vk::Format::R32G32B32_SFLOAT,
+            offset: offset_of!(Vertex, color) as _,
+        };
+
+        let coords_desc = vk::VertexInputAttributeDescription {
+            location: 2,
+            binding: 0,
+            format: vk::Format::R32G32_SFLOAT,
+            offset: offset_of!(Vertex, coords) as _,
+        };
+
+        [position_desc, color_desc, coords_desc]
+    }
+}


### PR DESCRIPTION
Issues this PR resolves:

1. The project wouldn't build at all with some internal winit issues on that version
```bash
error: internal compiler error: compiler/rustc_hir_typeck/src/mem_categorization.rs:489:13: cat_overloaded_place: base is not a reference
```
2. After upgrading winit, other dependencies were no longer compatible and needed to be upgraded or new dependencies added
3. After adding all of the dependencies some code was no longer standard for ash or winit and required manual changes
4. MacOS requires additional [flags and extensions](https://vulkan.lunarg.com/doc/view/latest/mac/getting_started.html) 