### PR TITLE
Fixes

### DIFF
--- a/src/debug.rs
+++ b/src/debug.rs
@@ -73,7 +73,19 @@ pub fn setup_debug_messenger(
         return None;
     }
 
-    let create_info = vk::DebugUtilsMessengerCreateInfoEXT::default()
+    let create_info = create_debug_create_info();
+    let debug_utils = debug_utils::Instance::new(entry, instance);
+    let debug_utils_messenger = unsafe {
+        debug_utils
+            .create_debug_utils_messenger(&create_info, None)
+            .unwrap()
+    };
+
+    Some((debug_utils, debug_utils_messenger))
+}
+
+pub fn create_debug_create_info() -> vk::DebugUtilsMessengerCreateInfoEXT<'static> {
+    vk::DebugUtilsMessengerCreateInfoEXT::default()
         .flags(vk::DebugUtilsMessengerCreateFlagsEXT::empty())
         .message_severity(
             vk::DebugUtilsMessageSeverityFlagsEXT::ERROR
@@ -85,13 +97,5 @@ pub fn setup_debug_messenger(
                 | vk::DebugUtilsMessageTypeFlagsEXT::VALIDATION
                 | vk::DebugUtilsMessageTypeFlagsEXT::PERFORMANCE,
         )
-        .pfn_user_callback(Some(vulkan_debug_callback));
-    let debug_utils = debug_utils::Instance::new(entry, instance);
-    let debug_utils_messenger = unsafe {
-        debug_utils
-            .create_debug_utils_messenger(&create_info, None)
-            .unwrap()
-    };
-
-    Some((debug_utils, debug_utils_messenger))
+        .pfn_user_callback(Some(vulkan_debug_callback))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,8 +42,8 @@ fn main() {
 
 #[derive(Default)]
 struct App {
-    window: Option<Window>,
     vulkan: Option<VulkanApp>,
+    window: Option<Window>,
 }
 
 impl ApplicationHandler for App {

--- a/src/main.rs
+++ b/src/main.rs
@@ -384,13 +384,16 @@ impl VulkanApp {
         } else {
             vk::InstanceCreateFlags::default()
         };
+        let mut debug_create_info = create_debug_create_info();
         let mut instance_create_info = vk::InstanceCreateInfo::default()
             .application_info(&app_info)
             .enabled_extension_names(&extension_names)
             .flags(create_flags);
         if ENABLE_VALIDATION_LAYERS {
             check_validation_layer_support(entry);
-            instance_create_info = instance_create_info.enabled_layer_names(&layer_names_ptrs);
+            instance_create_info = instance_create_info
+                .enabled_layer_names(&layer_names_ptrs)
+                .push_next(&mut debug_create_info);
         }
 
         unsafe { entry.create_instance(&instance_create_info, None).unwrap() }


### PR DESCRIPTION
There are 3 commits here:
1. Fix segmentation fault when closing the app, caused by drop order on `struct App`
2. When starting the app, swapchain is always recreated because resize event is emitted on opening the window. Also in this commit there is a fix for passing correct dimensions to `create_swapchain_and_images`
3. Enable validation layers on `create_instance` call as described in vulkan tutorial chapter [Debugging instance creation and destruction](https://vulkan-tutorial.com/Drawing_a_triangle/Setup/Validation_layers#page_Debugging-instance-creation-and-destruction)